### PR TITLE
docs: fix README CI badge to point at autorelease workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # lucasew's offtopic
 
-[![GitHub Pages](https://github.com/lucasew/lucasew.github.io/actions/workflows/gh-pages.yaml/badge.svg)](https://github.com/lucasew/lucasew.github.io/actions/workflows/gh-pages.yaml)
+[![Autorelease](https://github.com/lucasew/lucasew.github.io/actions/workflows/autorelease.yaml/badge.svg)](https://github.com/lucasew/lucasew.github.io/actions/workflows/autorelease.yaml)


### PR DESCRIPTION
## Summary

README badge still pointed at `actions/workflows/gh-pages.yaml`, which is gone. Deploy CI lives in `.github/workflows/autorelease.yaml` (name: Autorelease).

- Badge image + link → `autorelease.yaml`
- Label → Autorelease (matches workflow name)

## Test plan

- [x] Confirmed `.github/workflows/autorelease.yaml` exists in tree
- [ ] Open README on GitHub after merge; badge should render and link to Autorelease runs