### PR TITLE
Update shell.nix for Astro/Node (drop Hugo)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,9 +1,0 @@
-{ pkgs ? import <nixpkgs> {}}:
-
-pkgs.mkShell {
-  packages = with pkgs; [
-    dprint
-    ltex-ls
-    nodejs
-  ];
-}

--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,7 @@
 pkgs.mkShell {
   packages = with pkgs; [
     dprint
-    hugo
     ltex-ls
+    nodejs
   ];
 }


### PR DESCRIPTION
## Summary

`shell.nix` still installed Hugo after the Astro migration. `mise.toml` pins Node 25; build is `npm run build` / Astro. A Hugo-only shell misleads local Nix dev.

- Remove `hugo`
- Add `nodejs` so `npm` works in the shell
- Keep `dprint` (format scripts / Helix) and `ltex-ls` (Helix markdown LS for `*.en.md` / `*.pt.md`)

## Test plan

- [ ] `nix-shell` provides `node`, `npm`, `dprint`, `ltex-ls`
- [ ] `hugo` is not on PATH
- [ ] `npm run build` works after `npm ci` (or existing `node_modules`)

Finding: `shell-nix-astro`