### PR TITLE
docs(agents): rewrite AGENTS.md for Astro stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This is a multilingual (English/Portuguese) Hugo-based blog.
+Multilingual (English/Portuguese) Astro blog.
 
 ## Security Note
 
@@ -8,24 +8,24 @@ Security headers are not a priority as there is no dynamic content or user data.
 
 ## Environment & Commands
 
-- **Setup**: `mise install`
-- **Dev**: `hugo server` (http://localhost:1313)
-- **Build**: `hugo` or `hugo --minify --baseURL https://lucasew.github.io`
-- **Format**: `dprint fmt`
-- **Maintenance**: `./update.sh` (runs Python scripts prefixed with `update_`)
+- **Setup**: `mise install` then `npm install`
+- **Dev**: `npm run dev` (`astro dev`, http://localhost:4321)
+- **Build**: `npm run build` (`astro build` → `public/`)
+- **Preview**: `npm run preview`
+- **Format**: `dprint fmt` or `npm run format`
+- **Maintenance**: `./update.sh` or `mise codegen` (runs executable `**/update_*` scripts)
 
 ## Architecture
 
-- **Structure**: `content/post/YYYYMMDD-slug/index.{en,pt}.md`
-- **Dates**: Derived from directory names via `content/post/update_dates.py`.
-- **Shortcodes**: `eval` (dynamic Hugo templates), `details` (collapsible).
-- **Layouts**: `utils_base16` (theme browser), `utils_home`, `slide`.
-- **Base16**: Themes generated via `content/utils/base16/update_data.py`.
+- **Posts**: `src/content/post/YYYYMMDD-slug/index.{en,pt}.{md,mdx}`
+- **Dates**: Directory name prefix via `src/content/post/update_dates.py`
+- **Collections**: `src/content.config.ts` (glob loader for posts)
+- **Key dirs**: `src/pages/`, `src/layouts/`, `src/lib/`, `src/components/`
+- **Static assets**: `static/` (Astro `publicDir`) → site root
+- **i18n**: `en` / `pt` (`src/lib/i18n.ts`, `i18n/*.yaml`)
 
 ## Important Notes
 
-- **Hugo Version**: Must match in `mise.toml` and `vercel.json`. mise.toml takes
-  precedence.
-- **Goldmark**: Unsafe mode is enabled for raw HTML.
-- **CI/CD**: GitHub Actions (`.github/workflows/gh-pages.yaml`) runs
-  `./update.sh` weekly and on push.
+- **Node**: version from `mise.toml` (`node` tool only)
+- **CI/CD**: `.github/workflows/autorelease.yaml` — `npm install`, `mise codegen`, `npm run build`, deploy Pages on `main`
+- **Site URL**: `https://lucasew.github.io` (`astro.config.mjs` / Vercel `public` output)


### PR DESCRIPTION
## Problem

`AGENTS.md` still describes a Hugo site: `hugo server`/`hugo` build, `content/post/`, Goldmark, Hugo version sync with `vercel.json`, and `.github/workflows/gh-pages.yaml`. Agents following it run wrong commands and edit wrong paths.

## Change

Rewrite `AGENTS.md` only for the current Astro stack:

- Setup: `mise install` + `npm install`
- Dev/build/format via `package.json` scripts
- Maintenance: `./update.sh` / `mise codegen`
- Content: `src/content/post/YYYYMMDD-slug/index.{en,pt}.{md,mdx}`
- Key dirs: `src/pages`, `src/layouts`, `src/lib`, `src/components`
- CI: `.github/workflows/autorelease.yaml`

## Verify

Spot-checked against `package.json`, `mise.toml`, `astro.config.mjs`, `src/content.config.ts`, and the live workflow file. No code changes.