### PR TITLE
chore: refresh .gitignore for Astro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,6 @@
-# Generated files by hugo
+# Astro build output (outDir) and cache
 /public/
-/resources/_gen/
-/assets/jsconfig.json
-hugo_stats.json
+.astro/
 
-# Executable may be added to repository
-hugo.exe
-hugo.darwin
-hugo.linux
-
-# Temporary lock file while building
-/.hugo_build.lock
-node_modules
-hugo.log
-.astro
-.astro
+# Dependencies
+node_modules/


### PR DESCRIPTION
## Problem

`.gitignore` still described a Hugo build (`/resources/_gen/`, `hugo_stats.json`, `hugo.exe`/`darwin`/`linux`, `/.hugo_build.lock`, "Generated files by hugo") while the site builds with Astro (`outDir: public`, `publicDir: static`). `.astro` was listed twice.

## Change

- Keep ignoring `public/` (build output) and `node_modules/`
- Keep a single `.astro/` entry for the Astro cache
- Remove Hugo binaries, lockfile, `resources/_gen`, `assets/jsconfig.json`, `hugo_stats.json`, and `hugo.log`
- Comments now match the Astro layout

No other files touched. Nothing previously ignored is force-added.

## Verify

- Diff is only `.gitignore`
- `astro.config.mjs` still uses `outDir: 'public'`
- CI builds with `npm run build` and uploads `./public` (no Hugo steps)