### PR TITLE
🧹 Janitor: remove unused Hugo-era i18n YAML

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,4 +1,0 @@
-- id: also-available-on
-  translation: Also available on
-- id: discussed-on
-  translation: Discussed on

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -1,4 +1,0 @@
-- id: also-available-on
-  translation: Também disponível em
-- id: discussed-on
-  translation: Discutido em


### PR DESCRIPTION
## Problem

`i18n/en.yaml` and `i18n/pt.yaml` are leftovers from Hugo. After the Astro migration, the same UI strings (`also-available-on`, `discussed-on`) live in `src/lib/i18n.ts` via `t()`. Nothing under `src/`, package scripts, or the Astro config loads those YAML files. Keeping both systems around makes it easy to edit the wrong place.

## Change

- Delete `i18n/en.yaml` and `i18n/pt.yaml`
- Remove the empty `i18n/` directory

`src/lib/i18n.ts` is unchanged.

## Verified

- `rg` finds no imports or config references to `i18n/*.yaml` from Astro/src/build
- Site build path is `astro build` (not Hugo); mise no longer pins Hugo