### PR TITLE
fix(tailwind): point content globs at Astro sources

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,8 +3,8 @@ import daisyui from 'daisyui'
 
 export default {
   content: [
+    './src/**/*.{astro,ts,md,mdx}',
     './layouts/**/*.html',
-    './content/**/*.md',
   ],
   theme: {
     extend: {},


### PR DESCRIPTION
## Problem

`tailwind.config.ts` still listed Hugo-era content globs:

- `./layouts/**/*.html` (still valid for LegacyHome / leftover templates)
- `./content/**/*.md` — wrong root; posts live under `src/content/`, and there is no top-level `content/`

Real sources are under `src/` (`*.astro`, `*.ts`, markdown/mdx). `src/styles/global.css` already uses Tailwind v4 `@source` for those paths; the config globs were stale for any tooling that still reads `tailwind.config.ts`.

## Change

Update `content` to:

- `./src/**/*.{astro,ts,md,mdx}`
- `./layouts/**/*.html` (kept on purpose — those HTML files still carry utility classes)

Plugins left alone (`daisyui` stays as-is). No CSS changes.

## Verified

- Confirmed no top-level `content/` directory
- Confirmed posts under `src/content/**/*.{md,mdx}`
- Confirmed Tailwind utility classes still appear under top-level `layouts/**/*.html`
- Diff limited to `tailwind.config.ts` content array