### PR TITLE
fix: drop duplicate charset meta in utils_home baseof

### DIFF
--- a/layouts/utils_home/baseof.html
+++ b/layouts/utils_home/baseof.html
@@ -9,7 +9,6 @@
 <head>
   <title>{{ .Site.Title }}</title>
   <meta charset="UTF-8">
-  <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   {{- if hugo.IsProduction | or (eq .Site.Params.env "production") }}


### PR DESCRIPTION
## Summary

`layouts/utils_home/baseof.html` declared charset twice (`UTF-8` and `utf-8`). HTML only allows one charset meta, and the extra tag is redundant.

`LegacyHomeLayout.astro` still loads this template at runtime. Same class of fix already applied in `layouts/_default/baseof.html`.

## Change

- Keep `<meta charset="UTF-8">`
- Remove the duplicate `<meta charset="utf-8">`

No other edits.

## Test plan

- [ ] Confirm only one `meta charset` remains in `layouts/utils_home/baseof.html`
- [ ] Spot-check utils/home HTML output if that path is exercised in preview