### PR TITLE
refactor(i18n): route BaseLayout chrome strings through t()

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,6 +4,7 @@ import ProgressBar from '../components/ProgressBar.astro'
 import SiteIcon from '../components/SiteIcon.astro'
 import ThemeToggle from '../components/ThemeToggle.astro'
 import { getSectionTitle, type Entry } from '../lib/content'
+import { t } from '../lib/i18n'
 import '../styles/global.css'
 
 interface Props {
@@ -12,8 +13,8 @@ interface Props {
 }
 
 const { entry, translations } = Astro.props
-const postTitle = getSectionTitle(entry.lang, ['post']) || (entry.lang === 'pt' ? 'Publicações' : 'Posts')
-const utilsTitle = getSectionTitle(entry.lang, ['utils']) || (entry.lang === 'pt' ? 'Utilitários' : 'Utilities')
+const postTitle = getSectionTitle(entry.lang, ['post']) || t(entry.lang, 'posts')
+const utilsTitle = getSectionTitle(entry.lang, ['utils']) || t(entry.lang, 'utilities')
 ---
 
 <!doctype html>
@@ -24,7 +25,7 @@ const utilsTitle = getSectionTitle(entry.lang, ['utils']) || (entry.lang === 'pt
     <meta name="robots" content="index, follow" />
     <meta name="description" content={entry.summary ?? ''} />
     <meta name="mdpath" content={entry.sourceFile} />
-    <link rel="alternate" type="application/rss+xml" title={entry.lang === 'pt' ? 'RSS em português' : 'RSS in English'} href={`/${entry.lang}/post/index.xml`} />
+    <link rel="alternate" type="application/rss+xml" title={t(entry.lang, 'rss-title')} href={`/${entry.lang}/post/index.xml`} />
     <title>{entry.title}</title>
     <script is:inline>
       const themeKey = 'theme'
@@ -48,7 +49,7 @@ const utilsTitle = getSectionTitle(entry.lang, ['utils']) || (entry.lang === 'pt
         <div class="navbar-start">
           <a href={`/${entry.lang}/`} class="flex items-center gap-2">
             <SiteIcon id="icon" class="block m-0" size="2rem" />
-            <b class="leading-none">{entry.lang === 'pt' ? 'offtopic do lucasew' : "lucasew's offtopic"}</b>
+            <b class="leading-none">{t(entry.lang, 'site-title')}</b>
           </a>
         </div>
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -59,15 +59,31 @@ export function toUrl(lang: Lang, slug: string[]): string {
  * @param key - The strictly typed translation key
  * @returns The translated string
  */
-export function t(lang: Lang, key: 'also-available-on' | 'discussed-on'): string {
-  const table: Record<Lang, Record<string, string>> = {
+export type UiKey =
+  | 'also-available-on'
+  | 'discussed-on'
+  | 'site-title'
+  | 'rss-title'
+  | 'posts'
+  | 'utilities'
+
+export function t(lang: Lang, key: UiKey): string {
+  const table: Record<Lang, Record<UiKey, string>> = {
     en: {
       'also-available-on': 'Also available on',
       'discussed-on': 'Discussed on',
+      'site-title': "lucasew's offtopic",
+      'rss-title': 'RSS in English',
+      posts: 'Posts',
+      utilities: 'Utilities',
     },
     pt: {
       'also-available-on': 'Também disponível em',
       'discussed-on': 'Discutido em',
+      'site-title': 'offtopic do lucasew',
+      'rss-title': 'RSS em português',
+      posts: 'Publicações',
+      utilities: 'Utilitários',
     },
   }
 


### PR DESCRIPTION
## Summary

BaseLayout had bilingual UI copy inline (`site-title`, RSS link title, Posts/Utilities fallbacks). Those strings now go through `t()` in `src/lib/i18n.ts` next to the existing chrome keys.

No visual or behavior change — same pt/en wording, just one dictionary for template strings.

## Changes

- `src/lib/i18n.ts`: add `site-title`, `rss-title`, `posts`, `utilities` keys; export `UiKey` for the typed table
- `src/layouts/BaseLayout.astro`: call `t(entry.lang, …)` instead of ternaries

## Test plan

- [x] `npm run build` succeeds
- [x] Built `/en/` and `/pt/` still show the same brand, RSS titles, and nav labels