### PR TITLE
docs(agents): drop stale i18n/*.yaml pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Security headers are not a priority as there is no dynamic content or user data.
 - **Collections**: `src/content.config.ts` (glob loader for posts)
 - **Key dirs**: `src/pages/`, `src/layouts/`, `src/lib/`, `src/components/`
 - **Static assets**: `static/` (Astro `publicDir`) → site root
-- **i18n**: `en` / `pt` (`src/lib/i18n.ts`, `i18n/*.yaml`)
+- **i18n**: `en` / `pt` (`src/lib/i18n.ts`)
 
 ## Important Notes
 


### PR DESCRIPTION
## Problem

`AGENTS.md` still listed i18n as `src/lib/i18n.ts, i18n/*.yaml`. The Hugo-era `i18n/` YAML files were removed; UI strings live only in `src/lib/i18n.ts`. Agents following the old pointer look for missing files.

## Change

Point the Architecture i18n bullet at `src/lib/i18n.ts` only.

## Verify

- Confirmed `i18n/` is absent on current main
- Confirmed `src/lib/i18n.ts` is the live dictionary
- Diff is one line in `AGENTS.md`