### PR TITLE
refactor: route RSS feed title/description through i18n.t()

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -64,6 +64,8 @@ export type UiKey =
   | 'discussed-on'
   | 'site-title'
   | 'rss-title'
+  | 'rss-feed-title'
+  | 'rss-feed-description'
   | 'posts'
   | 'utilities'
 
@@ -74,6 +76,8 @@ export function t(lang: Lang, key: UiKey): string {
       'discussed-on': 'Discussed on',
       'site-title': "lucasew's offtopic",
       'rss-title': 'RSS in English',
+      'rss-feed-title': "lucasew's blog posts",
+      'rss-feed-description': 'RSS feed for English posts',
       posts: 'Posts',
       utilities: 'Utilities',
     },
@@ -82,6 +86,8 @@ export function t(lang: Lang, key: UiKey): string {
       'discussed-on': 'Discutido em',
       'site-title': 'offtopic do lucasew',
       'rss-title': 'RSS em português',
+      'rss-feed-title': 'Posts do blog do lucasew',
+      'rss-feed-description': 'Feed RSS das publicações em português',
       posts: 'Publicações',
       utilities: 'Utilitários',
     },

--- a/src/pages/[lang]/post/index.xml.ts
+++ b/src/pages/[lang]/post/index.xml.ts
@@ -1,6 +1,6 @@
 import rss from '@astrojs/rss'
 import type { APIRoute } from 'astro'
-import { LANGS, type Lang } from '../../../lib/i18n'
+import { LANGS, t, type Lang } from '../../../lib/i18n'
 import { allEntries } from '../../../lib/content'
 import { renderHtml } from '../../../lib/markdown'
 
@@ -52,10 +52,8 @@ export const GET: APIRoute = async ({ params, site }) => {
     })
 
   return rss({
-    title: lang === 'pt' ? 'Posts do blog do lucasew' : "lucasew's blog posts",
-    description: lang === 'pt'
-      ? 'Feed RSS das publicações em português'
-      : 'RSS feed for English posts',
+    title: t(lang, 'rss-feed-title'),
+    description: t(lang, 'rss-feed-description'),
     site: site ? new URL(site) : new URL('https://lucasew.github.io'),
     xmlns: {
       content: 'http://purl.org/rss/1.0/modules/content/',


### PR DESCRIPTION
## Summary

- Add `rss-feed-title` and `rss-feed-description` to `UiKey` and the en/pt table in `src/lib/i18n.ts` (same wording as before).
- Use `t(lang, ...)` in `src/pages/[lang]/post/index.xml.ts` instead of lang ternaries.

Feed structure, item content, and sort order are unchanged.

## Finding

`rss-use-i18n-t` — Inconsistent wording/terms: RSS handler hard-coded bilingual title/description while other chrome strings use `t()`.

## Test plan

- [ ] Confirm only exclusive paths changed
- [ ] `npm run build` succeeds
- [ ] `/en/post/index.xml` still has title `lucasew's blog posts` and English description
- [ ] `/pt/post/index.xml` still has title `Posts do blog do lucasew` and Portuguese description