### PR TITLE
refactor: use i18n.t() for ContentEntry also-available / discussed-on

### DIFF
--- a/src/components/ContentEntry.astro
+++ b/src/components/ContentEntry.astro
@@ -6,6 +6,7 @@ import {
   getTranslations,
   type Entry,
 } from '../lib/content'
+import { t } from '../lib/i18n'
 import { renderHtml, renderInline } from '../lib/markdown'
 
 interface Props {
@@ -28,14 +29,14 @@ function renderPostLinks(item: Entry): string {
     const links = alsoAvailable
       .map((href, idx) => `<a target="_blank" rel="noopener noreferrer" href="${href}">[${idx + 1}]</a>`)
       .join(' ')
-    lines.push(`<i>${item.lang === 'pt' ? 'Também disponível em' : 'Also available on'}: ${links}</i><br/>`)
+    lines.push(`<i>${t(item.lang, 'also-available-on')}: ${links}</i><br/>`)
   }
 
   if (discussedOn.length > 0) {
     const links = discussedOn
       .map((href, idx) => `<a target="_blank" rel="noopener noreferrer" href="${href}">[${idx + 1}]</a>`)
       .join(' ')
-    lines.push(`<i>${item.lang === 'pt' ? 'Discutido em' : 'Discussed on'}: ${links}</i><br/>`)
+    lines.push(`<i>${t(item.lang, 'discussed-on')}: ${links}</i><br/>`)
   }
 
   return lines.join('\n')


### PR DESCRIPTION
## Summary
- Import `t` from `src/lib/i18n` in `ContentEntry.astro`
- Replace hard-coded bilingual ternaries with `t(lang, 'also-available-on')` and `t(lang, 'discussed-on')`
- Keys already exist in `UiKey` / `t()` (same strings as before)

## Finding
`contententry-use-t` — ContentEntry still hard-coded chrome strings while BaseLayout routes through `t()`.

## Test plan
- [ ] Confirm page with `alsoAvailable` / `discussedOn` frontmatter still renders the same labels in `en` and `pt`
- [ ] Smoke-check that no other files changed