### PR TITLE
fix: stop utils/home CSS from breaking post prose

### DIFF
--- a/src/layouts/UtilsHomeLayout.astro
+++ b/src/layouts/UtilsHomeLayout.astro
@@ -27,20 +27,26 @@ const homeHref = `/${lang}/`
     />
   </head>
   <body>
+    {/*
+      Styles must stay under .utils-home. This layout is imported by the same
+      route module as normal posts ([section]/[slug]), so unscoped / is:global
+      rules (especially `* { margin:0; padding:0 }`) leak into article prose.
+    */}
     <style is:global>
-      :root {
+      .utils-home {
         font-family:
           -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
           sans-serif;
       }
 
-      * {
+      .utils-home,
+      .utils-home * {
         margin: 0;
         padding: 0;
         box-sizing: border-box;
       }
 
-      #container {
+      .utils-home {
         display: flex;
         overflow: auto;
         flex: none;
@@ -51,7 +57,7 @@ const homeHref = `/${lang}/`
         scroll-snap-type: y mandatory;
       }
 
-      #container > section {
+      .utils-home > section {
         width: 100%;
         height: 100%;
         scroll-snap-align: start;
@@ -62,41 +68,41 @@ const homeHref = `/${lang}/`
         flex-direction: column;
       }
 
-      section#firstpage {
+      .utils-home > section#firstpage {
         background-color: #65c9ff;
       }
 
-      section#firstpage > svg {
+      .utils-home > section#firstpage > svg {
         justify-self: flex-end;
-        animation: appear 1s;
+        animation: utils-home-appear 1s;
       }
 
-      section#firstpage h1 {
+      .utils-home > section#firstpage h1 {
         text-align: center;
         font-size: 2rem;
-        animation: fadeIn 0.5s;
+        animation: utils-home-fade-in 0.5s;
       }
 
-      div#title-contact {
+      .utils-home #title-contact {
         display: flex;
         flex-direction: column;
         align-items: center;
       }
 
-      div#title-contact > * {
+      .utils-home #title-contact > * {
         padding: 1rem;
       }
 
-      p#frase {
+      .utils-home #frase {
         transition: opacity 1s linear 0s;
         opacity: 0;
       }
 
-      g#eyes > * {
-        animation: blink 5s infinite;
+      .utils-home g#eyes > * {
+        animation: utils-home-blink 5s infinite;
       }
 
-      @keyframes fadeIn {
+      @keyframes utils-home-fade-in {
         0% {
           opacity: 0;
         }
@@ -105,7 +111,7 @@ const homeHref = `/${lang}/`
         }
       }
 
-      @keyframes appear {
+      @keyframes utils-home-appear {
         0% {
           margin-bottom: -300px;
         }
@@ -114,7 +120,7 @@ const homeHref = `/${lang}/`
         }
       }
 
-      @keyframes blink {
+      @keyframes utils-home-blink {
         0% {
           opacity: 1;
         }
@@ -130,7 +136,7 @@ const homeHref = `/${lang}/`
       }
     </style>
 
-    <div id="container">
+    <div class="utils-home" id="container">
       <section id="firstpage">
         <div></div>
         <div></div>

--- a/src/pages/[lang]/[section]/[slug]/index.astro
+++ b/src/pages/[lang]/[section]/[slug]/index.astro
@@ -1,18 +1,15 @@
 ---
 import ContentEntry from '../../../../components/ContentEntry.astro'
-import UtilsHomeLayout from '../../../../layouts/UtilsHomeLayout.astro'
 import {
   getEntryByUrl,
   getStaticPathsForSegments,
 } from '../../../../lib/content'
 
-function asStringArray(value: unknown): string[] {
-  if (!Array.isArray(value)) return []
-  return value.filter((item): item is string => typeof item === 'string')
-}
-
 export function getStaticPaths() {
-  return getStaticPathsForSegments(['lang', 'section', 'slug'])
+  // utils/home has a dedicated page so UtilsHomeLayout CSS is not pulled into posts
+  return getStaticPathsForSegments(['lang', 'section', 'slug']).filter(
+    ({ params }) => !(params.section === 'utils' && params.slug === 'home'),
+  )
 }
 
 const { lang, section, slug } = Astro.params
@@ -21,20 +18,6 @@ const entry = getEntryByUrl(urlPath)
 if (!entry) {
   Astro.response.status = 404
 }
-
-const isUtilsHome = entry
-  ? entry.slugSegments.length >= 2 && entry.slugSegments[0] === 'utils' && entry.slugSegments[1] === 'home'
-  : false
 ---
 
-{
-  !entry ? null : isUtilsHome ? (
-    <UtilsHomeLayout
-      lang={entry.lang}
-      title={entry.title}
-      quotes={asStringArray(entry.frontmatter.quotes)}
-    />
-  ) : (
-    <ContentEntry entry={entry} />
-  )
-}
+{entry ? <ContentEntry entry={entry} /> : null}

--- a/src/pages/[lang]/utils/home/index.astro
+++ b/src/pages/[lang]/utils/home/index.astro
@@ -1,0 +1,26 @@
+---
+import UtilsHomeLayout from '../../../../layouts/UtilsHomeLayout.astro'
+import { getEntry } from '../../../../lib/content'
+import { LANGS, type Lang } from '../../../../lib/i18n'
+
+export function getStaticPaths() {
+  return LANGS.map((lang) => ({ params: { lang } }))
+}
+
+const lang = Astro.params.lang as Lang
+const entry = getEntry(lang, ['utils', 'home'])
+if (!entry) {
+  return Astro.redirect(`/${lang}/`)
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value.filter((item): item is string => typeof item === 'string')
+}
+---
+
+<UtilsHomeLayout
+  lang={entry.lang}
+  title={entry.title}
+  quotes={asStringArray(entry.frontmatter.quotes)}
+/>


### PR DESCRIPTION
## Problem

[Não diga só olá](https://lucasew.github.io/pt/post/20210811-naodigaola/) (and other 3-segment post routes) lost normal spacing: headings, lists, and prose looked crushed / unstyled.

Cause: after the utils/home Astro migration, `UtilsHomeLayout` was still **imported by the same page module** as posts (`[lang]/[section]/[slug]`). Its `style is:global` included a universal reset:

```css
* { margin: 0; padding: 0; box-sizing: border-box; }
```

That CSS shipped on every post HTML page and undid Tailwind Typography margins.

## Fix

1. Scope all utils/home rules under `.utils-home` (no bare `*` / `:root` reset).
2. Move utils/home to `src/pages/[lang]/utils/home/index.astro` so post routes do not import that layout at all.
3. Exclude `utils/home` from the generic 3-segment static paths.

## Verify

- `npm run build` green
- `public/pt/post/20210811-naodigaola/index.html` has no `firstpage` / utils-home reset styles
- `public/pt/utils/home/` still builds with scoped styles